### PR TITLE
Fix the Webpack5 deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "terser-webpack-plugin": "^3.0.8",
     "webpack": "^5.76.0",
     "webpack-cli": "^5.0.1",
-    "webpack-fix-style-only-entries": "^0.5.1",
+    "webpack-remove-empty-scripts": "^1.0.4",
     "lodash": ">=4.17.21"
   },
   "dependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-const FixStyleOnlyEntriesPlugin = require("webpack-fix-style-only-entries");
+const RemoveEmptyScripts = require("webpack-remove-empty-scripts");
 
 
 module.exports = {
@@ -24,7 +24,7 @@ module.exports = {
   plugins: [
      new CleanWebpackPlugin(),
      new MiniCssExtractPlugin({filename: "docsify-iframe.min.css"}),
-     new FixStyleOnlyEntriesPlugin(),
+     new RemoveEmptyScripts(),
      new OptimizeCSSAssetsPlugin({})
   ],
   output: {


### PR DESCRIPTION
Hello,

this project uses the outdated [webpack-fix-style-only-entries](https://www.npmjs.com/package/webpack-fix-style-only-entries) plugin that is incompatible with `Webpack 5`.
The author of the `webpack-fix-style-only-entries` plugin recommends using the [webpack-remove-empty-scripts](https://github.com/webdiscus/webpack-remove-empty-scripts) plugin for Webpack 5.

When using the `webpack-fix-style-only-entries` plugin with Webpack 5 appear the deprecation warnings:
```
webpack-fix-style-only-entries:
(node:18462) [DEP_WEBPACK_CHUNK_ENTRY_MODULE] DeprecationWarning: Chunk.entryModule: Use new ChunkGraph API
(node:18462) [DEP_WEBPACK_MODULE_INDEX] DeprecationWarning: Module.index: Use new ModuleGraph API
(node:18462) [DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET] DeprecationWarning: chunk.files was changed from Array to Set (using Array method 'filter' is deprecated)
```

This PR just replaces the outdated plugin with the actual version.